### PR TITLE
Add support for VA-API in the Snap

### DIFF
--- a/package/snap/snap/snapcraft.yaml
+++ b/package/snap/snap/snapcraft.yaml
@@ -90,6 +90,7 @@ parts:
       - gstreamer1.0-plugins-base
       - gstreamer1.0-plugins-good
       - gstreamer1.0-libav
+      - gstreamer1.0-vaapi
       - gir1.2-gst-plugins-base-1.0
     build-environment:
       # https://bugs.launchpad.net/snapcraft/+bug/1802345
@@ -107,3 +108,4 @@ apps:
     environment:
       PYTHONPATH: "$SNAP/usr/src/brainframe-api:$SNAP/usr/local/lib/python3.6/site-packages:$PYTHONPATH"
       QT_STYLE_OVERRIDE: "adwaita-dark"
+      LIBVA_DRIVERS_PATH: "$SNAP/usr/lib/x86_64-linux-gnu/dri"


### PR DESCRIPTION
This allows Snap users to get hardware accelerated decoding on VA-API compatible devices, like most Intel processors.

Fixes #150 