### PR TITLE
Add gstreamer1.0-plugins-bad (to get HLS plugin)

### DIFF
--- a/package/snap/snap/snapcraft.yaml
+++ b/package/snap/snap/snapcraft.yaml
@@ -89,6 +89,7 @@ parts:
       - libgirepository-1.0-1
       - gstreamer1.0-plugins-base
       - gstreamer1.0-plugins-good
+      - gstreamer1.0-plugins-bad
       - gstreamer1.0-libav
       - gir1.2-gst-plugins-base-1.0
     build-environment:


### PR DESCRIPTION
Closes https://github.com/aotuai/brainframe-qt/issues/105

Because gstly's logic prevents BrainFrame from choosing anything other than the HLS (http livestream) plugin from gstreamer1.0-plugins-bad, this should be fine to add from a licensing perspective.