### PR TITLE
Fix task config overwriting global render configuration

### DIFF
--- a/brainframe_qt/ui/dialogs/task_configuration/task_configuration.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/task_configuration.py
@@ -3,14 +3,14 @@ from typing import Optional
 from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QInputDialog
 from PyQt5.uic import loadUi
+
 from brainframe.api.bf_codecs import StreamConfiguration, Zone
 
 from brainframe_qt.api_utils import api
 from brainframe_qt.ui.dialogs import AlarmCreationDialog
 from brainframe_qt.ui.resources import QTAsyncWorker
 from brainframe_qt.ui.resources.paths import qt_ui_paths
-from brainframe_qt.ui.resources.ui_elements.widgets.dialogs import \
-    BrainFrameMessage
+from brainframe_qt.ui.resources.ui_elements.widgets.dialogs import BrainFrameMessage
 from .video_task_config import VideoTaskConfig
 
 

--- a/brainframe_qt/ui/dialogs/task_configuration/video_task_config/video_task_config.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/video_task_config/video_task_config.py
@@ -6,12 +6,14 @@ from PyQt5.QtGui import QMouseEvent
 from PyQt5.QtWidgets import QWidget
 from shapely import geometry
 
-from brainframe_qt.api_utils.streaming.zone_status_frame import \
-    ZoneStatusFrame
+from brainframe_qt.api_utils.streaming.zone_status_frame import ZoneStatusFrame
 from brainframe_qt.ui.resources.video_items.base import VideoItem
 from brainframe_qt.ui.resources.video_items.streams import StreamWidget
-from brainframe_qt.ui.resources.video_items.zones import \
-    InProgressLineItem, InProgressRegionItem, InProgressZoneItem
+from brainframe_qt.ui.resources.video_items.zones import (
+    InProgressLineItem,
+    InProgressRegionItem,
+    InProgressZoneItem
+)
 
 
 class VideoTaskConfig(StreamWidget):
@@ -28,9 +30,9 @@ class VideoTaskConfig(StreamWidget):
         self.setMouseTracking(True)
 
         # Always draw regions and lines. Never draw detections.
-        self.render_config.draw_regions = True
-        self.render_config.draw_lines = True
-        self.render_config.draw_detections = False
+        self.draw_regions = True
+        self.draw_lines = True
+        self.draw_detections = False
 
         self.in_progress_zone: Optional[InProgressZoneItem] = None
         """Displays to the user a zone with all the points they've chosen,

--- a/brainframe_qt/ui/resources/video_items/streams/stream_widget.py
+++ b/brainframe_qt/ui/resources/video_items/streams/stream_widget.py
@@ -19,6 +19,10 @@ class StreamWidget(StreamWidgetUI, StreamListenerWidget):
     def __init__(self, *, parent: QWidget):
         super().__init__(parent=parent)
 
+        self._draw_lines: Optional[bool] = None
+        self._draw_regions: Optional[bool] = None
+        self._draw_detections: Optional[bool] = None
+
     def resizeEvent(self, _event: Optional[QResizeEvent] = None) -> None:
         """Take up entire width using aspect ratio of scene"""
 
@@ -29,6 +33,39 @@ class StreamWidget(StreamWidgetUI, StreamListenerWidget):
             # The sceneRect grows but never shrinks automatically
             self.scene().setSceneRect(current_frame.boundingRect())
             self.fitInView(current_frame.boundingRect(), Qt.KeepAspectRatio)
+
+    @property
+    def draw_lines(self) -> bool:
+        if self._draw_lines is None:
+            return self.render_config.draw_lines
+        else:
+            return self._draw_lines
+
+    @draw_lines.setter
+    def draw_lines(self, draw_lines: bool):
+        self._draw_lines = draw_lines
+
+    @property
+    def draw_regions(self) -> bool:
+        if self._draw_regions is None:
+            return self.render_config.draw_regions
+        else:
+            return self._draw_regions
+
+    @draw_regions.setter
+    def draw_regions(self, draw_regions: bool):
+        self._draw_regions = draw_regions
+
+    @property
+    def draw_detections(self) -> bool:
+        if self._draw_detections is None:
+            return self.render_config.draw_detections
+        else:
+            return self._draw_detections
+
+    @draw_detections.setter
+    def draw_detections(self, draw_detections: bool):
+        self._draw_detections = draw_detections
 
     def on_frame(self, frame: ZoneStatusFrame) -> None:
 
@@ -43,13 +80,13 @@ class StreamWidget(StreamWidgetUI, StreamListenerWidget):
         if frame.zone_statuses is None:
             return
 
-        if self.render_config.draw_lines:
+        if self.draw_lines:
             self.scene().draw_lines(frame.zone_statuses)
 
-        if self.render_config.draw_regions:
+        if self.draw_regions:
             self.scene().draw_regions(frame.zone_statuses)
 
-        if self.render_config.draw_detections:
+        if self.draw_detections:
             self.scene().draw_detections(
                 frame_tstamp=frame.tstamp,
                 tracks=frame.tracks


### PR DESCRIPTION
I spent some time trying to create a read-only view of the `SettingsManager` object, but I couldn't find a clean solution. Maybe in the future, I'll revisit that idea, but for now I just gave the `StreamWidget` some properties to override

Resolves #154 