### PR TITLE
Convert StreamManager and SyncedStreamReader to QObjects

### DIFF
--- a/brainframe_qt/api_utils/__init__.py
+++ b/brainframe_qt/api_utils/__init__.py
@@ -10,13 +10,29 @@ api = BrainFrameAPI()
 from .streaming import StreamManager
 
 # Set using init_stream_manager before use
+#
+# Note: Creating singleton QObjects is a bit of a hassle because they need a parent
+# object. Flutter has a really cool system called InheritedWidget/Provider that makes
+# passing objects like this around really easily. I'd like to implement something
+# similar, but for now this is the only singleton object we have so I think this
+# should be begrudgingly "ok".
 _stream_manager: StreamManager = typing.cast(StreamManager, None)
 
 
 def init_stream_manager(*, parent: QObject) -> None:
     global _stream_manager
+
+    if _stream_manager is not None:
+        raise RuntimeError("StreamManager has already been initialized")
+
     _stream_manager = StreamManager(parent=parent)
 
 
 def get_stream_manager() -> StreamManager:
+    if _stream_manager is None:
+        raise RuntimeError(
+            f"StreamManager has not been initialized yet. Call "
+            f"{init_stream_manager.__name__} first."
+        )
+
     return _stream_manager

--- a/brainframe_qt/api_utils/__init__.py
+++ b/brainframe_qt/api_utils/__init__.py
@@ -1,5 +1,22 @@
-from brainframe.api import BrainFrameAPI
-from .streaming import StreamManager, StreamManagerAPI
+import typing
 
-# API instance that is later monkeypatched to be a singleton
-api: BrainFrameAPI = StreamManagerAPI()
+from PyQt5.QtCore import QObject
+from brainframe.api import BrainFrameAPI
+
+# Singleton API instance
+api = BrainFrameAPI()
+
+# Must come after api import
+from .streaming import StreamManager
+
+# Set using init_stream_manager before use
+_stream_manager: StreamManager = typing.cast(StreamManager, None)
+
+
+def init_stream_manager(*, parent: QObject) -> None:
+    global _stream_manager
+    _stream_manager = StreamManager(parent=parent)
+
+
+def get_stream_manager() -> StreamManager:
+    return _stream_manager

--- a/brainframe_qt/api_utils/streaming/__init__.py
+++ b/brainframe_qt/api_utils/streaming/__init__.py
@@ -1,3 +1,3 @@
-from .stream_manager import StreamManager, StreamManagerAPI
+from .stream_manager import StreamManager
 from .synced_reader import SyncedStreamReader
 from .stream_listener import StreamListener

--- a/brainframe_qt/api_utils/streaming/stream_manager.py
+++ b/brainframe_qt/api_utils/streaming/stream_manager.py
@@ -1,7 +1,8 @@
 import logging
-from typing import Dict, List
+import typing
+from typing import Dict, Optional
 
-from PyQt5.QtCore import QObject
+from PyQt5.QtCore import QObject, QThread
 
 from brainframe.api.bf_codecs import StreamConfiguration
 from gstly import gobject_init
@@ -20,15 +21,12 @@ class StreamManager(QObject):
         StreamConfiguration.ConnType.WEBCAM,
         StreamConfiguration.ConnType.FILE,
     ]
-    """These video types are re-hosted by the server."""
+    """Video types that are re-hosted by the server"""
 
     def __init__(self, *, parent: QObject):
         super().__init__(parent=parent)
 
         self._stream_readers: Dict[int, SyncedStreamReader] = {}
-        self._async_closing_streams: List[SyncedStreamReader] = []
-        """A list of StreamReader objects that are closing or may have finished
-        closing"""
 
         self._init_signals()
 
@@ -37,92 +35,110 @@ class StreamManager(QObject):
 
     def start_streaming(
         self,
-        stream_config: StreamConfiguration,
+        stream_conf: StreamConfiguration,
         url: str
     ) -> SyncedStreamReader:
         """Starts reading from the stream using the given information, or returns an
         existing reader if we're already reading this stream.
 
-        :param stream_config: The stream to connect to
+        :param stream_conf: The stream to connect to
         :param url: The URL to stream on
-        :return: A Stream object
+        :return: A SyncedStreamReader for the stream
         """
-        if not self.is_streaming(stream_config.id):
-            # pipeline will be None if not in the options
-            pipeline: str = stream_config.connection_options.get("pipeline")
+        if not self.is_streaming(stream_conf.id):
+            synced_stream_reader = self._create_synced_reader(stream_conf, url)
+            self._stream_readers[stream_conf.id] = synced_stream_reader
 
-            latency = StreamReader.DEFAULT_LATENCY
-            if stream_config.connection_type in self.REHOSTED_VIDEO_TYPES:
-                latency = StreamReader.REHOSTED_LATENCY
-
-            gobject_init.start()
-
-            # Streams created with a premises are always proxied from that premises
-            is_proxied = stream_config.premises_id is not None
-
-            stream_reader = GstStreamReader(
-                url,
-                latency=latency,
-                runtime_options=stream_config.runtime_options,
-                pipeline_str=pipeline,
-                proxied=is_proxied)
-
-            synced_stream_reader = SyncedStreamReader(
-                stream_config.id,
-                stream_reader,
-                parent=self,
-            )
-
-            self._stream_readers[stream_config.id] = synced_stream_reader
-
-        return self._stream_readers[stream_config.id]
+        return self._stream_readers[stream_conf.id]
 
     def is_streaming(self, stream_id: int) -> bool:
-        """Checks if the the manager has a stream reader for the given stream
-        id.
+        """Checks if the the manager has a stream reader for the given stream id.
 
         :param stream_id: The stream ID to check
-        :return: True if the stream manager has a stream reader, false
-            otherwise
+        :return: True if the stream manager has a stream reader, false otherwise
         """
         return stream_id in self._stream_readers
 
     def close_stream(self, stream_id: int) -> None:
-        """Close a specific stream and remove the reference.
+        """Requests a stream to close asynchronously
 
         :param stream_id: The ID of the stream to delete
         """
-        stream = self.close_stream_async(stream_id)
-        stream.wait_until_closed()
+        stream_reader = self._stream_readers[stream_id]
+        stream_reader.close()
 
     def close(self) -> None:
-        """Close all streams and remove references"""
-        for stream_id in self._stream_readers.copy().keys():
-            self.close_stream_async(stream_id)
-        self._stream_readers = {}
-
-        for stream in self._async_closing_streams:
-            stream.wait_until_closed()
-            self._async_closing_streams.remove(stream)
-
-    def close_stream_async(self, stream_id: int) -> SyncedStreamReader:
-        stream = self._stream_readers.pop(stream_id)
-        self._async_closing_streams.append(stream)
-        stream.close()
-        return stream
+        """Request and wait for all streams to close"""
+        logging.info("Initiating StreamManager close")
+        stream_readers = self._stream_readers.values()
+        for stream_reader in stream_readers:
+            stream_reader.close()
+        for stream_reader in stream_readers:
+            stream_reader.wait_until_closed()
+        logging.info("StreamManager close finished")
 
     def delete_stream(self, stream_id: int, timeout: int = 120) -> None:
+        """Delete a stream through the API and initiate the closing of its corresponding
+        StreamReader"""
         api.delete_stream_configuration(stream_id, timeout=timeout)
         if self.is_streaming(stream_id):
-            self.close_stream_async(stream_id)
+            self.close_stream(stream_id)
 
-    def get_stream_reader(self, stream_config: StreamConfiguration):
+    def get_stream_reader(
+        self, stream_config: StreamConfiguration
+    ) -> SyncedStreamReader:
         """Get the SyncedStreamReader for the given stream_configuration.
 
         :param stream_config: The stream configuration to open.
         :return: A SyncedStreamReader object
         """
         url = api.get_stream_url(stream_config.id)
-        logging.info("API: Opening stream on url " + url)
+        logging.info(f"API: Opening stream on url {url}")
 
         return self.start_streaming(stream_config, url)
+
+    def _create_synced_reader(
+        self, stream_conf: StreamConfiguration, url: str
+    ) -> SyncedStreamReader:
+        pipeline: Optional[str] = stream_conf.connection_options.get("pipeline")
+
+        latency = StreamReader.DEFAULT_LATENCY
+        if stream_conf.connection_type in self.REHOSTED_VIDEO_TYPES:
+            latency = StreamReader.REHOSTED_LATENCY
+
+        gobject_init.start()
+
+        # Streams created with a premises are always proxied from that premises
+        is_proxied = stream_conf.premises_id is not None
+
+        stream_reader = GstStreamReader(
+            url,
+            latency=latency,
+            runtime_options=stream_conf.runtime_options,
+            pipeline_str=pipeline,
+            proxied=is_proxied)
+
+        synced_stream_reader = SyncedStreamReader(
+            stream_conf.id,
+            stream_reader,
+            # No parent if moving to a different thread
+            parent=typing.cast(QObject, None),
+        )
+
+        thread = QThread(parent=self)
+
+        synced_stream_reader.moveToThread(thread)
+        thread.started.connect(synced_stream_reader.run)
+        synced_stream_reader.finished.connect(thread.quit)
+
+        thread.finished.connect(thread.deleteLater)
+        synced_stream_reader.finished.connect(
+            lambda: self._remove_stream_reference(stream_conf.id)
+        )
+
+        thread.start()
+
+        return synced_stream_reader
+
+    def _remove_stream_reference(self, stream_id: int) -> None:
+        self._stream_readers.pop(stream_id)

--- a/brainframe_qt/api_utils/streaming/synced_reader.py
+++ b/brainframe_qt/api_utils/streaming/synced_reader.py
@@ -57,7 +57,7 @@ class SyncedStreamReader(StreamReader, QObject, metaclass=ABCObject):
             self.status is not StreamStatus.CLOSED
             and not self.thread().isInterruptionRequested()
         ):
-            if not frame_or_status_event.wait(10):
+            if not frame_or_status_event.wait(0.1):
                 continue
 
             if self._stream_reader.new_status_event.is_set():

--- a/brainframe_qt/ui/brainframe_app.py
+++ b/brainframe_qt/ui/brainframe_app.py
@@ -12,7 +12,7 @@ from brainframe.api import bf_errors
 from gstly import gobject_init
 
 import brainframe_qt
-from brainframe_qt.api_utils import api
+from brainframe_qt.api_utils import api, init_stream_manager
 from brainframe_qt.api_utils.connection_manager import ConnectionManager
 from brainframe_qt.extensions.loader import ExtensionLoader
 from brainframe_qt.ui import EULADialog, MainWindow, SplashScreen
@@ -193,6 +193,10 @@ class BrainFrameApplication(SingletonApplication):
             server_version = api.version()
             if server_version != brainframe_qt.__version__:
                 self._handle_version_mismatch(server_version)
+
+            # Initialize the StreamManager
+            # TODO: Find a better way of doing this
+            init_stream_manager(parent=self)
 
             ExtensionLoader().load_extensions()
 

--- a/brainframe_qt/ui/brainframe_app.py
+++ b/brainframe_qt/ui/brainframe_app.py
@@ -12,7 +12,7 @@ from brainframe.api import bf_errors
 from gstly import gobject_init
 
 import brainframe_qt
-from brainframe_qt.api_utils import api, init_stream_manager
+from brainframe_qt.api_utils import api, init_stream_manager, get_stream_manager
 from brainframe_qt.api_utils.connection_manager import ConnectionManager
 from brainframe_qt.extensions.loader import ExtensionLoader
 from brainframe_qt.ui import EULADialog, MainWindow, SplashScreen
@@ -181,6 +181,8 @@ class BrainFrameApplication(SingletonApplication):
     def _shutdown(self):
         api.close()
         gobject_init.close()
+
+        get_stream_manager().close()
 
         self.connection_manager.requestInterruption()
         self.connection_manager.wait(5000)  # milliseconds

--- a/brainframe_qt/ui/brainframe_app.py
+++ b/brainframe_qt/ui/brainframe_app.py
@@ -182,8 +182,11 @@ class BrainFrameApplication(SingletonApplication):
         api.close()
         gobject_init.close()
 
-        stream_manager = get_stream_manager()
-        if stream_manager is not None:
+        try:
+            stream_manager = get_stream_manager()
+        except RuntimeError:
+            pass
+        else:
             stream_manager.close()
 
         self.connection_manager.requestInterruption()

--- a/brainframe_qt/ui/brainframe_app.py
+++ b/brainframe_qt/ui/brainframe_app.py
@@ -182,7 +182,9 @@ class BrainFrameApplication(SingletonApplication):
         api.close()
         gobject_init.close()
 
-        get_stream_manager().close()
+        stream_manager = get_stream_manager()
+        if stream_manager is not None:
+            stream_manager.close()
 
         self.connection_manager.requestInterruption()
         self.connection_manager.wait(5000)  # milliseconds

--- a/brainframe_qt/ui/main_window/activities/stream_configuration/stream_configuration.py
+++ b/brainframe_qt/ui/main_window/activities/stream_configuration/stream_configuration.py
@@ -694,7 +694,7 @@ class StreamConfiguration(StreamConfigurationUI):
         if isinstance(exc, bf_errors.AnalysisLimitExceededError):
             # Delete the stream configuration, since you almost never want to
             # have a stream that can't have analysis running
-            QTAsyncWorker(self, get_stream_manager().delete_stream_configuration,
+            QTAsyncWorker(self, get_stream_manager().delete_stream,
                           f_args=(stream_conf.id,)) \
                 .start()
 

--- a/brainframe_qt/ui/main_window/activities/stream_configuration/stream_configuration.py
+++ b/brainframe_qt/ui/main_window/activities/stream_configuration/stream_configuration.py
@@ -6,19 +6,16 @@ from typing import Callable, List, Optional, Union
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QKeyEvent
 from PyQt5.QtWidgets import QDialogButtonBox, QWidget
+
 from brainframe.api import bf_codecs, bf_errors
 
-from brainframe_qt.api_utils import api
+from brainframe_qt.api_utils import api, get_stream_manager
 from brainframe_qt.ui.main_window.activities.stream_configuration \
     .stream_configuration_ui import StreamConfigurationUI
-from brainframe_qt.ui.resources import CanceledError, ProgressFileReader, \
-    QTAsyncWorker
-from brainframe_qt.ui.resources.links.documentation \
-    import IP_CAMERA_DOCS_LINK
-from brainframe_qt.ui.resources.ui_elements.widgets import \
-    FileUploadProgressDialog
-from brainframe_qt.ui.resources.ui_elements.widgets.dialogs import \
-    BrainFrameMessage
+from brainframe_qt.ui.resources import CanceledError, ProgressFileReader, QTAsyncWorker
+from brainframe_qt.ui.resources.links.documentation import IP_CAMERA_DOCS_LINK
+from brainframe_qt.ui.resources.ui_elements.widgets import FileUploadProgressDialog
+from brainframe_qt.ui.resources.ui_elements.widgets.dialogs import BrainFrameMessage
 
 
 class StreamConfiguration(StreamConfigurationUI):
@@ -697,7 +694,7 @@ class StreamConfiguration(StreamConfigurationUI):
         if isinstance(exc, bf_errors.AnalysisLimitExceededError):
             # Delete the stream configuration, since you almost never want to
             # have a stream that can't have analysis running
-            QTAsyncWorker(self, api.delete_stream_configuration,
+            QTAsyncWorker(self, get_stream_manager().delete_stream_configuration,
                           f_args=(stream_conf.id,)) \
                 .start()
 

--- a/brainframe_qt/ui/main_window/video_expanded_view/video_expanded_view.py
+++ b/brainframe_qt/ui/main_window/video_expanded_view/video_expanded_view.py
@@ -4,16 +4,16 @@ import typing
 from PyQt5.QtCore import QEvent, QTimerEvent, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QWidget
 from PyQt5.uic import loadUi
+
 from brainframe.api.bf_codecs import StreamConfiguration
 from requests.exceptions import RequestException
 
-from brainframe_qt.api_utils import api
+from brainframe_qt.api_utils import api, get_stream_manager
 from brainframe_qt.ui.dialogs import CapsuleConfigDialog, TaskConfiguration
 from brainframe_qt.ui.resources import QTAsyncWorker, stylesheet_watcher
 from brainframe_qt.ui.resources.paths import qt_qss_paths, qt_ui_paths
 from brainframe_qt.ui.resources.ui_elements.buttons import FloatingXButton
-from brainframe_qt.ui.resources.ui_elements.widgets.dialogs import \
-    BrainFrameMessage
+from brainframe_qt.ui.resources.ui_elements.widgets.dialogs import BrainFrameMessage
 
 
 class VideoExpandedView(QWidget):
@@ -146,7 +146,7 @@ class VideoExpandedView(QWidget):
 
         # Delete stream from database
         QTAsyncWorker(
-            self, api.delete_stream_configuration,
+            self, get_stream_manager().delete_stream,
             f_args=(self.stream_conf.id, 600)
         ).start()
 

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -282,7 +282,7 @@ Read the manual to learn about the required directory structure.&lt;br&gt;&lt;br
         <translation>连接服务器成功</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="212"/>
+        <location filename="../../brainframe_app.py" line="214"/>
         <source>Program Closing: License Not Accepted</source>
         <translation>程序正在关闭：授权不符</translation>
     </message>
@@ -332,12 +332,12 @@ Read the manual to learn about the required directory structure.&lt;br&gt;&lt;br
         <translation>。客户端必须关闭。</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="215"/>
+        <location filename="../../brainframe_app.py" line="217"/>
         <source>Version Mismatch</source>
         <translation>版本不匹配</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="216"/>
+        <location filename="../../brainframe_app.py" line="218"/>
         <source>The server is using version {server_version} but this client is on version {client_version}. Please download the matching version of the client at {download_url}.</source>
         <translation>正在使用的服务器版本为{server_version}，但是此客户端版本为{client_version}。请从{download_url}下载匹配版本的客户端。</translation>
     </message>

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -282,7 +282,7 @@ Read the manual to learn about the required directory structure.&lt;br&gt;&lt;br
         <translation>连接服务器成功</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="214"/>
+        <location filename="../../brainframe_app.py" line="219"/>
         <source>Program Closing: License Not Accepted</source>
         <translation>程序正在关闭：授权不符</translation>
     </message>
@@ -332,12 +332,12 @@ Read the manual to learn about the required directory structure.&lt;br&gt;&lt;br
         <translation>。客户端必须关闭。</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="217"/>
+        <location filename="../../brainframe_app.py" line="222"/>
         <source>Version Mismatch</source>
         <translation>版本不匹配</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="218"/>
+        <location filename="../../brainframe_app.py" line="223"/>
         <source>The server is using version {server_version} but this client is on version {client_version}. Please download the matching version of the client at {download_url}.</source>
         <translation>正在使用的服务器版本为{server_version}，但是此客户端版本为{client_version}。请从{download_url}下载匹配版本的客户端。</translation>
     </message>

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -282,7 +282,7 @@ Read the manual to learn about the required directory structure.&lt;br&gt;&lt;br
         <translation>连接服务器成功</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="208"/>
+        <location filename="../../brainframe_app.py" line="212"/>
         <source>Program Closing: License Not Accepted</source>
         <translation>程序正在关闭：授权不符</translation>
     </message>
@@ -332,12 +332,12 @@ Read the manual to learn about the required directory structure.&lt;br&gt;&lt;br
         <translation>。客户端必须关闭。</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="211"/>
+        <location filename="../../brainframe_app.py" line="215"/>
         <source>Version Mismatch</source>
         <translation>版本不匹配</translation>
     </message>
     <message>
-        <location filename="../../brainframe_app.py" line="212"/>
+        <location filename="../../brainframe_app.py" line="216"/>
         <source>The server is using version {server_version} but this client is on version {client_version}. Please download the matching version of the client at {download_url}.</source>
         <translation>正在使用的服务器版本为{server_version}，但是此客户端版本为{client_version}。请从{download_url}下载匹配版本的客户端。</translation>
     </message>
@@ -1148,87 +1148,87 @@ Please recheck the entered server address.</source>
 <context>
     <name>StreamConfiguration</name>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="653"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="650"/>
         <source>Error Opening Stream</source>
         <translation>打开视频流时出错</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="300"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="297"/>
         <source>Error encountered while uploading video file</source>
         <translation>上传视频文件过程中发生了一个错误</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="656"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="653"/>
         <source>Stream source already open</source>
         <translation>视频流源已经打开</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="657"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="654"/>
         <source>You already have the stream source open.</source>
         <translation>您已经打开了视频流源。</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="677"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="674"/>
         <source>Error: </source>
         <translation>错误： </translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="674"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="671"/>
         <source>Error encountered while opening stream</source>
         <translation>打开视频流时出错</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="675"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="672"/>
         <source>Is stream already open?</source>
         <translation>视频流是否已打开？</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="676"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="673"/>
         <source>Is this a valid stream source?</source>
         <translation>这是一个有效的视频流源吗？</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="704"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="701"/>
         <source>Active Stream Limit Exceeded</source>
         <translation>视频流数量超过上限</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="705"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="702"/>
         <source>You have exceeded the number of active streams available to you under the terms of your license. Consider deleting another stream or contacting Aotu to increase your active stream limit.</source>
         <translation>您已经超出了许可条款下可供使用的最大视频流数量，请考虑删除其他视频流或与Aotu联系以增加最大视频流限制。</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="720"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="717"/>
         <source>Error uploading file</source>
         <translation>上传文件时发生错误</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="721"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="718"/>
         <source>No such file: {filepath}</source>
         <translation>没有这样的文件：{filepath}</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="601"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="598"/>
         <source>Adding a webcam</source>
         <translation>添加一个网络摄像头</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="602"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="599"/>
         <source>Webcams and other video devices must be attached to the computer running the BrainFrame server.&lt;br&gt;&lt;br&gt;To add a webcam, open a terminal on the server machine and run &lt;pre&gt;ls /dev/video*&lt;/pre&gt;If you get a message about &quot;No such file or directory&quot;, you do not have any webcams attached to theserver computer.&lt;br&gt;&lt;br&gt;Otherwise, select the digit at the end of the results and provide it to BrainFrame. For example, if the command returns &quot;/dev/video0&quot;, input &quot;0&quot; (without the quotes).</source>
         <translation>网络摄像头和其他视频设备必须连接到运行BrainFrame的计算机。如果在启动BrainFrame后插入设备，请重新启动BrainFrame。&lt;br&gt;&lt;br&gt;要添加网络摄像头，请在服务器上打开终端并运行&lt;pre&gt;ls /dev/video*&lt;/pre&gt;如果收到类似“No such file or directory“的消息，则说明运行BrainFrame的计算机没有连接任何网络摄像头。&lt;br&gt;&lt;br&gt;否则，请选择结果末尾的数字并将其提供给BrainFrame。例如，如果命令返回“/dev/video0“，则输入“0“（不带引号）。</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="627"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="624"/>
         <source>Adding an IP Camera</source>
         <translation>添加IP摄像头</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="631"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="628"/>
         <source>Please see the &lt;a href=&apos;{ip_camera_docs_link}&apos;&gt;documentation&lt;/a&gt; for more information on adding IP Cameras.</source>
         <translation>有关添加IP摄像机的详细信息，请参见&lt;a href=&apos;{ip_camera_docs_link}&apos;&gt;文档&lt;/a&gt;。</translation>
     </message>
     <message>
-        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="628"/>
+        <location filename="../../main_window/activities/stream_configuration/stream_configuration.py" line="625"/>
         <source>Standard RTSP format:&lt;br&gt;{rtsp_format}</source>
         <translation>标准RTSP格式：&lt;br&gt;{rtsp_format}</translation>
     </message>

--- a/brainframe_qt/ui/resources/video_items/streams/stream_listener_widget.py
+++ b/brainframe_qt/ui/resources/video_items/streams/stream_listener_widget.py
@@ -2,13 +2,12 @@ from typing import Optional
 
 from PyQt5.QtCore import QCoreApplication, QTimer
 from PyQt5.QtWidgets import QWidget
+
 from brainframe.api import bf_codecs, bf_errors
 
-from brainframe_qt.api_utils import api
-from brainframe_qt.api_utils.streaming import StreamListener, \
-    SyncedStreamReader
-from brainframe_qt.api_utils.streaming.zone_status_frame import \
-    ZoneStatusFrame
+from brainframe_qt.api_utils import api, get_stream_manager
+from brainframe_qt.api_utils.streaming import StreamListener, SyncedStreamReader
+from brainframe_qt.api_utils.streaming.zone_status_frame import ZoneStatusFrame
 from brainframe_qt.ui.resources import QTAsyncWorker
 
 
@@ -118,8 +117,8 @@ class StreamListenerWidget(QWidget, StreamListener):
             -> None:
 
         # Create the stream reader
-        stream_reader = api.get_stream_manager() \
-            .start_streaming(stream_conf, stream_url)
+        stream_manager = get_stream_manager()
+        stream_reader = stream_manager.start_streaming(stream_conf, stream_url)
 
         if stream_reader is None:
             # This will happen if we try to get a StreamReader for a stream


### PR DESCRIPTION
This PR changes the `StreamManager` and `SyncedStreamReader` objects to be QObjects. This allows me to use Qt slots and signals for a better asynchronous design. 

Recommended review process would involve looking at each commit one-by-one, otherwise it becomes a mess.