### PR TITLE
Fix "No image for alert" not showing up when an alert is missing an image

### DIFF
--- a/brainframe_qt/ui/dialogs/alert_entry_popup/alert_entry_popup.py
+++ b/brainframe_qt/ui/dialogs/alert_entry_popup/alert_entry_popup.py
@@ -1,4 +1,4 @@
-from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtGui import QImage, QPixmap, QIcon
 from PyQt5.QtWidgets import QDialog, QLabel
 from PyQt5.QtCore import QSize, Qt
 from PyQt5.uic import loadUi
@@ -30,6 +30,10 @@ class AlertEntryPopup(QDialog):
 
     def get_frame(self, alert_id):
         frame = api.get_alert_frame(alert_id)
+
+        if frame is None:
+            icon = QIcon(":/images/no_image_svg")
+            return icon.pixmap(QSize(1000, 1000))
 
         height, width, channels = frame.shape
         bytes_per_line = width * channels

--- a/brainframe_qt/ui/resources/alarms/alarm_bundle/alarm_card/alert_log/alert_log_entry/alert_preview/alert_preview.py
+++ b/brainframe_qt/ui/resources/alarms/alarm_bundle/alarm_card/alert_log/alert_log_entry/alert_preview/alert_preview.py
@@ -76,7 +76,7 @@ class AlertPreviewUI(QFrame):
     def _get_no_image_available_image(cls):
         """Cache the no image available SVG as a 1920x1080 pixmap"""
         if cls._no_image_available_image is None:
-            icon = QIcon(":/images/no_image")
+            icon = QIcon(":/images/no_image_svg")
             cls._no_image_available_image = icon.pixmap(1920, 1080)
         return cls._no_image_available_image
 


### PR DESCRIPTION
Resolves #165 

The resource `:/images/no_image` was misnamed, and apparently even the alert tab would fail to load the `no image` resource. 

---

We used to have a `paths.py` which would check to make sure all resources exist during packaging. Unfortunately, it looks like switching to the QT resource way of packaging things is going to let things slip through the cracks. Is there a way to add a test to ensure that all used resources in the codebase actually exist and reference real files?