### PR TITLE
Bump gstly version to one with py3.9 linux wheels

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -80,15 +80,15 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "gstly"
-version = "0.1.7"
+version = "0.3.2"
 description = "Internal GStreamer libraries for BrainFrame"
 category = "main"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.6.2,<4.0.0"
 
 [package.dependencies]
 numpy = ">=1.16,<2.0"
-PyGObject = ">=3.34.0,<3.35.0"
+PyGObject = ">=3.34.0,<4.0.0"
 
 [[package]]
 name = "idna"
@@ -437,8 +437,8 @@ windows = ["gstly"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "6e5f567ea59359050ca8c752c69304b55cc03fad4621fd1233fa6abd0dc1fa41"
+python-versions = "^3.6.2"
+content-hash = "d0f503190d1c145d354a30bc244d5b0a933799d562433835732c2cc1c780ee5c"
 
 [metadata.files]
 altgraph = [
@@ -473,11 +473,14 @@ future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 gstly = [
-    {file = "gstly-0.1.7-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:3f17aa5467d07f0dd85e3fc7b00089f2762abcaa877f8e6f086f660739d69d9f"},
-    {file = "gstly-0.1.7-cp36-cp36m-win_amd64.whl", hash = "sha256:2421ac92de17db29a13fc1e3cc1acaa2a5ae4da76562b7339600dde7b091a77f"},
-    {file = "gstly-0.1.7-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:d43d6bc9618addb9c3be07a24ebd6c6d9fcf17b5efc7bb91ef2ce17d04d84164"},
-    {file = "gstly-0.1.7-cp37-cp37m-win_amd64.whl", hash = "sha256:3e21f747c54849264fd89ae49a7889d4ec5dd45f1087b7cf6eccece984f5b5be"},
-    {file = "gstly-0.1.7-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:d5b5ed099f35a9e19c9f283fda0deaabc93ad8e309d5d9addbe59d7771ec61e0"},
+    {file = "gstly-0.3.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:5b84336e7b521fcde8b4b531465051ef5664ec9a242b189a14d9ff8f71c25b77"},
+    {file = "gstly-0.3.2-cp36-cp36m-win_amd64.whl", hash = "sha256:113a5b788f0e7487421858c184c61966603f3bba642e19bef910af5b2565886a"},
+    {file = "gstly-0.3.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:12519ed8f2f81fb36504249875e5821cb200a48521df5fe2b0d4f6719695fa17"},
+    {file = "gstly-0.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bdef1e870606c1d3a3a60359f7574da47326c22429b3e531803a31459b0a3458"},
+    {file = "gstly-0.3.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:c3a31b0765835ff8fefa1845424b8ba41c2a9206ebb1bd319e4beb235d24f186"},
+    {file = "gstly-0.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:e146e3ddbb071112e38359c0cc8ef991be7c3860afd1de6fd7df81579aa1c709"},
+    {file = "gstly-0.3.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:96ca62124fe0563d778a6d36d1b013ed491e902b4831b22a8f6e799ff48c5d3f"},
+    {file = "gstly-0.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:4e8064a2222426502ce3c5b20555ac5dbee5f24e905c30901325ada5d4cd94b9"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -740,26 +743,18 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -791,7 +786,6 @@ shapely = [
     {file = "Shapely-1.7.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:90a3e2ae0d6d7d50ff2370ba168fbd416a53e7d8448410758c5d6a5920646c1d"},
     {file = "Shapely-1.7.1-cp38-cp38-win32.whl", hash = "sha256:a3774516c8a83abfd1ddffb8b6ec1b0935d7fe6ea0ff5c31a18bfdae567b4eba"},
     {file = "Shapely-1.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:6593026cd3f5daaea12bcc51ae5c979318070fefee210e7990cb8ac2364e79a1"},
-    {file = "Shapely-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:617bf046a6861d7c6b44d2d9cb9e2311548638e684c2cd071d8945f24a926263"},
     {file = "Shapely-1.7.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b40cc7bb089ae4aa9ddba1db900b4cd1bce3925d2a4b5837b639e49de054784f"},
     {file = "Shapely-1.7.1-cp39-cp39-win32.whl", hash = "sha256:2df5260d0f2983309776cb41bfa85c464ec07018d88c0ecfca23d40bfadae2f1"},
     {file = "Shapely-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:a5c3a50d823c192f32615a2a6920e8c046b09e07a58eba220407335a9cd2e8ea"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ pycryptodomex = "^3.9.6"
 pendulum = "^2.0.5"
 dataclasses = { version = "^0.7", python = ">=3.6,<3.7" }
 gstly = [
-    { version = "^0.1.7", platform = 'linux' },
-    { version = "^0.1.7", platform = 'windows', optional = true },
+    { version = "^0.3.2", platform = 'linux' },
+    { version = "^0.3.2", platform = 'windows', optional = true },
 ]
 
 pyqt5ac = { version = "^1.1.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Aotu"]
 license = "Proprietary"
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6.2"
 brainframe-api = "^0.28.1"
 # Windows is locked to 1.16, due to gcc version on windows being 8.3. https://github.com/numpy/numpy/issues/14787
 numpy = [


### PR DESCRIPTION
Partially addresses #170, but does not add the env vars