### PR TITLE
Add check for Gstly source in Snap build

### DIFF
--- a/package/snap/snap/snapcraft.yaml
+++ b/package/snap/snap/snapcraft.yaml
@@ -60,8 +60,8 @@ parts:
       cp brainframe_client.py $PYTHON_INSTALL_DIR/
 
       # Check that no Gstly source is in the build
-      export GSTLY_PATH=$(python3 -c "from pathlib import Path; import gstly; print(Path(gstly.__file__).parent)")
-      if [ $(find ${GSTLY_PATH} -name "*.py" | wc -l) -gt 0 ]; then false; fi
+      export GSTLY_PATH=$(python3 -c "import pathlib, gstly; print(pathlib.Path(gstly.__file__).parent)")
+      (find ${GSTLY_PATH} -name "*.py" | grep .) && false
     source: .
     build-packages:
       # Basic Python packages

--- a/package/snap/snap/snapcraft.yaml
+++ b/package/snap/snap/snapcraft.yaml
@@ -58,6 +58,10 @@ parts:
 
       # Add the main Python file
       cp brainframe_client.py $PYTHON_INSTALL_DIR/
+
+      # Check that no Gstly source is in the build
+      export GSTLY_PATH=$(python3 -c "from pathlib import Path; import gstly; print(Path(gstly.__file__).parent)")
+      if [ $(find ${GSTLY_PATH} -name "*.py" | wc -l) -gt 0 ]; then false; fi
     source: .
     build-packages:
       # Basic Python packages

--- a/package/snap/snap/snapcraft.yaml
+++ b/package/snap/snap/snapcraft.yaml
@@ -61,7 +61,7 @@ parts:
 
       # Check that no Gstly source is in the build
       export GSTLY_PATH=$(python3 -c "import pathlib, gstly; print(pathlib.Path(gstly.__file__).parent)")
-      (find ${GSTLY_PATH} -name "*.py" | grep .) && false
+      ! find ${GSTLY_PATH} -name "*.py" | grep .
     source: .
     build-packages:
       # Basic Python packages


### PR DESCRIPTION
Checks if Gstly source code is being included in the Snap. Gstly is currently a proprietary library, so we can't include the source code yet.