### PR TITLE
Re-enable editing existing zones

### DIFF
--- a/brainframe_qt/ui/dialogs/task_configuration/task_configuration.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/task_configuration.py
@@ -233,13 +233,7 @@ class TaskConfiguration(QDialog):
     def _edit_zone_by_id(self, zone_id: int) -> None:
         def _get_zone() -> Zone:
             api_zone = api.get_zone(zone_id)
-
-            client_zone = Zone.from_api_zone(api_zone)
-
-            # TODO: Remove with addition of point moving/deleting
-            client_zone.coords = []
-
-            return client_zone
+            return Zone.from_api_zone(api_zone)
 
         QTAsyncWorker(self, _get_zone, on_success=self.edit_zone).start()
 


### PR DESCRIPTION
In #186, we made it so that when zones are edited, the are restarted w/o any points as a temporary stop-gap until zone points can be rearranged, or at least removed. Later PRs will add both of those features and build upon this PR