### PR TITLE
Move `DraggableVertex` to its own file

### DIFF
--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/draggable_vertex.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/draggable_vertex.py
@@ -1,5 +1,4 @@
 from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QGraphicsSceneMouseEvent
 
 from brainframe_qt.ui.resources.video_items.base import CircleItem, VideoItem
 
@@ -15,14 +14,3 @@ class DraggableVertex(CircleItem):
                          radius=self.DEFAULT_RADIUS,
                          border_thickness=self.DEFAULT_BORDER_THICKNESS,
                          parent=parent)
-
-    #     self.setFlag(self.ItemIsSelectable, True)
-    #     self.setFlag(self.ItemIsMovable, True)
-    #
-    # def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
-    #     event.ignore()
-    #     super().mouseMoveEvent(event)
-    #
-    # def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
-    #     event.ignore()
-    #     super().mouseMoveEvent(event)

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/draggable_vertex.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/draggable_vertex.py
@@ -1,0 +1,28 @@
+from PyQt5.QtGui import QColor
+from PyQt5.QtWidgets import QGraphicsSceneMouseEvent
+
+from brainframe_qt.ui.resources.video_items.base import CircleItem, VideoItem
+
+
+class DraggableVertex(CircleItem):
+    # TODO: Tie to size of scene
+    DEFAULT_RADIUS = 10
+    DEFAULT_BORDER_THICKNESS = 5
+    DEFAULT_COLOR = QColor(200, 50, 50)
+
+    def __init__(self, position: VideoItem.PointType, *, parent: VideoItem):
+        super().__init__(position, color=self.DEFAULT_COLOR,
+                         radius=self.DEFAULT_RADIUS,
+                         border_thickness=self.DEFAULT_BORDER_THICKNESS,
+                         parent=parent)
+
+    #     self.setFlag(self.ItemIsSelectable, True)
+    #     self.setFlag(self.ItemIsMovable, True)
+    #
+    # def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+    #     event.ignore()
+    #     super().mouseMoveEvent(event)
+    #
+    # def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
+    #     event.ignore()
+    #     super().mouseMoveEvent(event)

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/in_progress_zone_item.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/in_progress_zone_item.py
@@ -62,9 +62,6 @@ class InProgressZoneItem(VideoItem, ABC):
 
         self.refresh_shape()
 
-        vertex_item = DraggableVertex(vertex, parent=self)
-        self._vertex_items.append(vertex_item)
-
     def refresh_shape(self) -> None:
         if self._zone_item is not None and self.scene() is not None:
             self.scene().removeItem(self._zone_item)

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/in_progress_zone_item.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/in_progress_zone_item.py
@@ -2,15 +2,15 @@ from abc import ABC, abstractmethod
 from typing import List, Optional
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor
 
 from brainframe.api import bf_codecs
 
 from brainframe_qt.ui.resources.config import RenderSettings
-from brainframe_qt.ui.resources.video_items.base import CircleItem, VideoItem
+from brainframe_qt.ui.resources.video_items.base import VideoItem
 from brainframe_qt.ui.resources.video_items.zones import ZoneLineItem, ZoneRegionItem
 
 from ..core.zone import Line, Region, Zone
+from .draggable_vertex import DraggableVertex
 
 
 class InProgressZoneItem(VideoItem, ABC):
@@ -62,7 +62,7 @@ class InProgressZoneItem(VideoItem, ABC):
 
         self.refresh_shape()
 
-        vertex_item = _DraggableVertex(vertex, parent=self)
+        vertex_item = DraggableVertex(vertex, parent=self)
         self._vertex_items.append(vertex_item)
 
     def refresh_shape(self) -> None:
@@ -82,12 +82,13 @@ class InProgressZoneItem(VideoItem, ABC):
             zone is not ready to be drawn yet
         """
 
-    def _init_vertex_items(self) -> List['_DraggableVertex']:
+    def _init_vertex_items(self) -> List['DraggableVertex']:
         assert self.zone.coords is not None
 
-        vertex_items: List[_DraggableVertex] = []
+        vertex_items: List[DraggableVertex] = []
         for coord in self.zone.coords:
-            vertex_items.append(_DraggableVertex(coord, parent=self))
+            vertex_item = DraggableVertex(coord, parent=self)
+            vertex_items.append(vertex_item)
 
         return vertex_items
 
@@ -122,27 +123,3 @@ class InProgressLineItem(InProgressZoneItem):
             line_style=self._line_style,
             parent=self
         )
-
-
-class _DraggableVertex(CircleItem):
-    # TODO: Tie to size of scene
-    DEFAULT_RADIUS = 10
-    DEFAULT_BORDER_THICKNESS = 5
-    DEFAULT_COLOR = QColor(200, 50, 50)
-
-    def __init__(self, position: VideoItem.PointType, *, parent: VideoItem):
-        super().__init__(position, color=self.DEFAULT_COLOR,
-                         radius=self.DEFAULT_RADIUS,
-                         border_thickness=self.DEFAULT_BORDER_THICKNESS,
-                         parent=parent)
-
-        # self.setFlag(self.ItemIsSelectable, True)
-        # self.setFlag(self.ItemIsMovable, True)
-
-    # def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
-    #     event.ignore()
-    #     super().mouseMoveEvent(event)
-    #
-    # def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
-    #     event.ignore()
-    #     super().mouseMoveEvent(event)

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/in_progress_zone_item.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/in_progress_zone_item.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from PyQt5.QtCore import Qt
 
@@ -29,6 +29,7 @@ class InProgressZoneItem(VideoItem, ABC):
         self._line_style = line_style
 
         self._zone_item = self._init_zone_item()
+        self._vertex_items: Dict[VideoItem.PointType, DraggableVertex]
         self._vertex_items = self._init_vertex_items()
 
     @classmethod
@@ -55,8 +56,7 @@ class InProgressZoneItem(VideoItem, ABC):
 
     def add_vertex(self, vertex: VideoItem.PointType) -> None:
         if not self.zone.takes_additional_points():
-            raise RuntimeError("This zone item does not support adding any "
-                               "more points")
+            raise RuntimeError("This zone item does not support adding any more points")
 
         self.zone.coords.append(vertex)
 
@@ -65,7 +65,7 @@ class InProgressZoneItem(VideoItem, ABC):
     def refresh_shape(self) -> None:
         if self._zone_item is not None and self.scene() is not None:
             self.scene().removeItem(self._zone_item)
-            for item in self._vertex_items:
+            for item in self._vertex_items.values():
                 self.scene().removeItem(item)
 
         self._zone_item = self._init_zone_item()
@@ -79,13 +79,13 @@ class InProgressZoneItem(VideoItem, ABC):
             zone is not ready to be drawn yet
         """
 
-    def _init_vertex_items(self) -> List['DraggableVertex']:
+    def _init_vertex_items(self) -> Dict[VideoItem.PointType, DraggableVertex]:
         assert self.zone.coords is not None
 
-        vertex_items: List[DraggableVertex] = []
+        vertex_items: Dict[VideoItem.PointType, DraggableVertex] = {}
         for coord in self.zone.coords:
             vertex_item = DraggableVertex(coord, parent=self)
-            vertex_items.append(vertex_item)
+            vertex_items[coord] = vertex_item
 
         return vertex_items
 

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/video_task_config.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/video_task_config.py
@@ -50,6 +50,8 @@ class VideoTaskConfig(StreamWidget):
 
             self._update_zone_items()
 
+        super().mouseMoveEvent(event)
+
     def _handle_click(self, click_pos: VideoItem.PointType) -> None:
         # Don't do anything if we're not currently making a zone
         if self.in_progress_zone is None:


### PR DESCRIPTION
Resolves #190. 

This was the work I had made while trying to implement Zone vertex moving/deleting. I'm backing off on that feature for now, so this PR just incorporates the minor changes I had made.

One functional change:
Now the `QGraphicsItem`s on the scene receive propagated mouse movement events, but they still don't use them. This is for a future change allowing vertices to be moved around.