### PR TITLE
Allow users to rename Zones

### DIFF
--- a/brainframe_qt/ui/dialogs/task_configuration/task_configuration.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/task_configuration.py
@@ -58,6 +58,7 @@ class TaskConfiguration(QDialog):
         self.zone_list.initiate_zone_edit.connect(self._edit_zone_by_id)
         self.zone_list.zone_delete.connect(self.delete_zone)
         self.zone_list.alarm_delete.connect(self.delete_alarm)
+        self.zone_list.zone_name_change.connect(self.change_zone_name)
 
         self.dialog_button_box.accepted.connect(self.accept)
         self.dialog_button_box.rejected.connect(self.reject)
@@ -170,6 +171,17 @@ class TaskConfiguration(QDialog):
 
         if None in self.zone_list.zones:
             self.zone_list.remove_zone(None)
+
+    def change_zone_name(self, zone_id: int, zone_name: str) -> None:
+        def update_zone_name() -> None:
+            zone = api.get_zone(zone_id)
+            zone.name = zone_name
+            updated_zone = api.set_zone(zone)
+
+        def on_error(error: Exception) -> None:
+            print(error)
+
+        QTAsyncWorker(self, update_zone_name, on_error=on_error).start()
 
     def delete_alarm(self, alarm_id: int) -> None:
         api.delete_zone_alarm(alarm_id)

--- a/brainframe_qt/ui/dialogs/task_configuration/task_configuration.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/task_configuration.py
@@ -185,16 +185,17 @@ class TaskConfiguration(QDialog):
 
         def on_error(error: Exception) -> None:
             dialog: Optional[BrainFrameMessage] = None
-            title = self.tr("Unable to rename zone")
+            title = self.tr("Unable to rename Zone")
 
             if isinstance(error, bf_errors.ZoneNotFoundError):
-                message = (
+                message = self.tr(
                     f"Attempted to rename Zone {zone_id} to {zone_name} but the Zone "
                     f"no longer exists."
                 )
                 try:
                     self.zone_list.remove_zone(zone_id)
                 except KeyError:
+                    # Zone must already be gone
                     pass
 
                 dialog = BrainFrameMessage.warning(

--- a/brainframe_qt/ui/dialogs/task_configuration/task_configuration.ui
+++ b/brainframe_qt/ui/dialogs/task_configuration/task_configuration.ui
@@ -150,6 +150,27 @@
          </property>
         </spacer>
        </item>
+        <item alignment="Qt::AlignHCenter">
+         <widget class="QLabel" name="rename_help_label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="font">
+           <font>
+            <weight>35</weight>
+           </font>
+          </property>
+          <property name="text">
+           <string>Double click a zone to rename it</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list.py
@@ -86,6 +86,8 @@ class ZoneList(QWidget):
 
         self.layout().removeWidget(alarm_widget)
 
+        alarm_widget.deleteLater()
+
     def remove_zone(self, zone_id: int) -> None:
         zone_widget: ZoneListZoneItem = self.zones.pop(zone_id)
 
@@ -97,6 +99,8 @@ class ZoneList(QWidget):
             # Uses private attribute for now, but this is temporary until zone widgets
             # contain alarm widgets inside of them
             self.remove_alarm(alarm_widget._alarm.id)
+
+        zone_widget.deleteLater()
 
     def _add_alarm_widget(self, alarm_widget: ZoneListAlarmItem, zone_id: int) -> None:
         """Add an alarm widget to the correct zone"""

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list.py
@@ -1,4 +1,4 @@
-from typing import Dict, Callable, List
+from typing import Callable, Dict, List, Optional
 
 from PyQt5.QtCore import pyqtSignal, Qt
 from PyQt5.QtWidgets import QWidget, QVBoxLayout
@@ -41,7 +41,7 @@ class ZoneList(QWidget):
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().setSpacing(0)
 
-    def add_zone(self, zone: Zone) -> ZoneListZoneItem:
+    def add_zone(self, zone: Zone, index: Optional[int] = None) -> ZoneListZoneItem:
         """Creates and returns the new ZoneListItem using the Zone"""
         zone_item = ZoneListZoneItem(zone, parent=self)
 
@@ -51,10 +51,12 @@ class ZoneList(QWidget):
         zone_item.zone_delete.connect(self.zone_delete)
         zone_item.zone_name_change.connect(self.zone_name_change)
 
-        self.layout().addWidget(zone_item)
+        if index is not None:
+            self.layout().insertWidget(index, zone_item)
+        else:
+            self.layout().addWidget(zone_item)
 
-        for alarm in zone.alarms:
-            self.add_alarm(zone, alarm)
+        self._add_alarm_widgets_for_zone(zone)
 
         return zone_item
 
@@ -66,11 +68,10 @@ class ZoneList(QWidget):
 
     def update_zone(self, zone: Zone) -> None:
         old_zone_widget = self.zones[zone.id]
-        new_zone_widget = self.add_zone(zone)
+        old_index = self.layout().indexOf(old_zone_widget)
 
-        self.layout().replaceWidget(old_zone_widget, new_zone_widget)
-
-        old_zone_widget.deleteLater()
+        self.remove_zone(zone.id)
+        self.add_zone(zone, old_index)
 
     def add_alarm(self, zone: Zone, alarm: bf_codecs.ZoneAlarm):
         alarm_widget = ZoneListAlarmItem(alarm, parent=self)
@@ -85,7 +86,6 @@ class ZoneList(QWidget):
         alarm_widget = self.alarms.pop(alarm_id)
 
         self.layout().removeWidget(alarm_widget)
-
         alarm_widget.deleteLater()
 
     def remove_zone(self, zone_id: int) -> None:
@@ -94,12 +94,11 @@ class ZoneList(QWidget):
         alarm_widgets = self._find_alarm_widgets_for_zone(zone_widget)
 
         # Remove zone and all child alarms
-        self.layout().removeWidget(zone_widget)
         for alarm_widget in alarm_widgets:
             # Uses private attribute for now, but this is temporary until zone widgets
             # contain alarm widgets inside of them
             self.remove_alarm(alarm_widget._alarm.id)
-
+        self.layout().removeWidget(zone_widget)
         zone_widget.deleteLater()
 
     def _add_alarm_widget(self, alarm_widget: ZoneListAlarmItem, zone_id: int) -> None:
@@ -117,6 +116,10 @@ class ZoneList(QWidget):
         insert_index = index + 1
 
         self.layout().insertWidget(insert_index, alarm_widget)
+
+    def _add_alarm_widgets_for_zone(self, zone: Zone) -> None:
+        for alarm in zone.alarms:
+            self.add_alarm(zone, alarm)
 
     def _find_alarm_widgets_for_zone(
         self, zone_widget: ZoneListZoneItem

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list.py
@@ -14,6 +14,8 @@ class ZoneList(QWidget):
     zone_delete = pyqtSignal(int)
     alarm_delete = pyqtSignal(int)
 
+    zone_name_change = pyqtSignal(int, str)
+
     layout: Callable[..., QVBoxLayout]
 
     def __init__(self, parent=None):
@@ -47,6 +49,7 @@ class ZoneList(QWidget):
 
         zone_item.zone_edit.connect(self.initiate_zone_edit)
         zone_item.zone_delete.connect(self.zone_delete)
+        zone_item.zone_name_change.connect(self.zone_name_change)
 
         self.layout().addWidget(zone_item)
 

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list.py
@@ -64,6 +64,14 @@ class ZoneList(QWidget):
         self.remove_zone(None)
         self.add_zone(zone)
 
+    def update_zone(self, zone: Zone) -> None:
+        old_zone_widget = self.zones[zone.id]
+        new_zone_widget = self.add_zone(zone)
+
+        self.layout().replaceWidget(old_zone_widget, new_zone_widget)
+
+        old_zone_widget.deleteLater()
+
     def add_alarm(self, zone: Zone, alarm: bf_codecs.ZoneAlarm):
         alarm_widget = ZoneListAlarmItem(alarm, parent=self)
 

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item.py
@@ -11,6 +11,7 @@ class ZoneListZoneItem(ZoneListItemUI):
 
     zone_delete = pyqtSignal(int)
     zone_edit = pyqtSignal(int)
+    zone_name_change = pyqtSignal(int, str)
 
     def __init__(self, zone: Zone, *, parent: QObject):
         super().__init__(parent=parent)
@@ -26,6 +27,7 @@ class ZoneListZoneItem(ZoneListItemUI):
     def _init_signals(self) -> None:
         self.trash_button.clicked.connect(self._on_trash_button_click)
         self.edit_button.clicked.connect(self._on_edit_button_click)
+        self.name_label.text_changed.connect(self._on_zone_name_change)
 
     def _configure_buttons(self) -> None:
         if self._zone.name == bf_codecs.Zone.FULL_FRAME_ZONE_NAME:
@@ -37,6 +39,9 @@ class ZoneListZoneItem(ZoneListItemUI):
 
     def _on_trash_button_click(self, _clicked: bool) -> None:
         self.zone_delete.emit(self._zone.id)
+
+    def _on_zone_name_change(self, zone_name: str) -> None:
+        self.zone_name_change.emit(self._zone.id, zone_name)
 
     @staticmethod
     def _get_entry_type(zone: Zone) -> ZoneListType:

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item.py
@@ -1,4 +1,7 @@
+from typing import Tuple
+
 from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtGui import QValidator
 from PyQt5.QtWidgets import QWidget
 
 from brainframe.api import bf_codecs
@@ -21,6 +24,7 @@ class ZoneListZoneItem(ZoneListItemUI):
         self.entry_name = zone.name
         self.entry_type = self._get_entry_type(zone)
 
+        self._init_validators()
         self._init_signals()
 
         self._handle_full_frame_zone()
@@ -29,6 +33,11 @@ class ZoneListZoneItem(ZoneListItemUI):
         self.trash_button.clicked.connect(self._on_trash_button_click)
         self.edit_button.clicked.connect(self._on_edit_button_click)
         self.name_label.text_changed.connect(self._on_zone_name_change)
+
+    def _init_validators(self) -> None:
+        validator = self._ZoneNameValidator()
+
+        self.name_label.validator = validator
 
     def _handle_full_frame_zone(self) -> None:
         """Disable some functionality if the Zone is the full-frame zone"""
@@ -55,6 +64,15 @@ class ZoneListZoneItem(ZoneListItemUI):
             return ZoneListType.REGION
         else:
             return ZoneListType.UNKNOWN
+
+    class _ZoneNameValidator(QValidator):
+        def validate(self, input_: str, pos: int) -> Tuple[QValidator.State, str, int]:
+            if input_ == bf_codecs.Zone.FULL_FRAME_ZONE_NAME:
+                state = QValidator.Intermediate
+            else:
+                state = QValidator.Acceptable
+
+            return state, input_, pos
 
 
 class ZoneListAlarmItem(ZoneListItemUI):

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item.py
@@ -22,17 +22,21 @@ class ZoneListZoneItem(ZoneListItemUI):
         self.entry_type = self._get_entry_type(zone)
 
         self._init_signals()
-        self._configure_buttons()
+
+        self._handle_full_frame_zone()
 
     def _init_signals(self) -> None:
         self.trash_button.clicked.connect(self._on_trash_button_click)
         self.edit_button.clicked.connect(self._on_edit_button_click)
         self.name_label.text_changed.connect(self._on_zone_name_change)
 
-    def _configure_buttons(self) -> None:
+    def _handle_full_frame_zone(self) -> None:
+        """Disable some functionality if the Zone is the full-frame zone"""
         if self._zone.name == bf_codecs.Zone.FULL_FRAME_ZONE_NAME:
             self.trash_button.setDisabled(True)
             self.edit_button.setDisabled(True)
+
+            self.name_label.editable = False
 
     def _on_edit_button_click(self, _clicked: bool) -> None:
         self.zone_edit.emit(self._zone.id)
@@ -56,6 +60,7 @@ class ZoneListZoneItem(ZoneListItemUI):
 class ZoneListAlarmItem(ZoneListItemUI):
     """Temporary until ZoneListZoneItem holds Alarm widgets"""
     alarm_delete = pyqtSignal(int)
+    alarm_edit = pyqtSignal(int)
 
     def __init__(self, alarm: bf_codecs.ZoneAlarm, *, parent: QObject):
         super().__init__(parent=parent)
@@ -69,8 +74,11 @@ class ZoneListAlarmItem(ZoneListItemUI):
 
         self._init_signals()
 
+        self._disable_editing()
+
     def _init_signals(self) -> None:
         self.trash_button.clicked.connect(self._on_trash_button_click)
+        self.edit_button.clicked.connect(self._on_edit_button_click)
 
     def _init_padding_widget(self) -> QWidget:
         """Temporary solution to indent alarm widgets a bit.
@@ -86,3 +94,15 @@ class ZoneListAlarmItem(ZoneListItemUI):
 
     def _on_trash_button_click(self, _clicked: bool) -> None:
         self.alarm_delete.emit(self._alarm.id)
+
+    def _on_edit_button_click(self, _clicked: bool) -> None:
+        self.alarm_edit.emit(self._alarm.id)
+
+    def _disable_editing(self) -> None:
+        """Editing of alarms is not currently supported"""
+        self.edit_button.setDisabled(True)
+        self.edit_button.setToolTip(self.tr(
+            "Editing of alarms is not currently not supported"
+        ))
+
+        self.name_label.editable = False

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item_ui.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item_ui.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 
 from PyQt5.QtCore import QObject, Qt
 from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QWidget, QHBoxLayout
+from PyQt5.QtWidgets import QWidget, QHBoxLayout, QLabel, QLineEdit
 
 from brainframe_qt.ui.resources.ui_elements.buttons import IconButton
 from brainframe_qt.ui.resources.ui_elements.widgets import AspectRatioSVGWidget
@@ -50,7 +50,10 @@ class ZoneListItemUI(QWidget):
         return icon
 
     def _init_name_label(self) -> EditableLabel:
-        label = EditableLabel(self._entry_name, parent=self)
+        label = QLabel(self._entry_name, parent=self)
+        line_edit = QLineEdit(parent=self)
+
+        label = EditableLabel(label, line_edit, parent=self)
 
         return label
 

--- a/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item_ui.py
+++ b/brainframe_qt/ui/dialogs/task_configuration/widgets/zone_list_item_ui.py
@@ -2,10 +2,11 @@ from enum import Enum, auto
 
 from PyQt5.QtCore import QObject, Qt
 from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QPushButton, QWidget, QHBoxLayout, QLabel
+from PyQt5.QtWidgets import QWidget, QHBoxLayout
 
 from brainframe_qt.ui.resources.ui_elements.buttons import IconButton
 from brainframe_qt.ui.resources.ui_elements.widgets import AspectRatioSVGWidget
+from brainframe_qt.ui.resources.ui_elements.widgets.text_edit import EditableLabel
 
 
 class ZoneListType(Enum):
@@ -48,8 +49,8 @@ class ZoneListItemUI(QWidget):
 
         return icon
 
-    def _init_name_label(self) -> QLabel:
-        label = QLabel(self._entry_name, parent=self)
+    def _init_name_label(self) -> EditableLabel:
+        label = EditableLabel(self._entry_name, parent=self)
 
         return label
 
@@ -93,7 +94,7 @@ class ZoneListItemUI(QWidget):
     @entry_name.setter
     def entry_name(self, entry_name: str) -> None:
         self._entry_name = entry_name
-        self.name_label.setText(entry_name)
+        self.name_label.text = entry_name
 
     @property
     def entry_type(self) -> ZoneListType:

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -1284,22 +1284,22 @@ Please recheck the entered server address.</source>
 <context>
     <name>TaskConfiguration</name>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="188"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="200"/>
         <source>Add points until done, then press &quot;Confirm&quot; button</source>
         <translation>添加点直到完成，然后按“确认”按钮</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="224"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="236"/>
         <source>Item Name Already Exists</source>
         <translation>名称已存在</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="225"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="237"/>
         <source>Item {} already exists in Stream</source>
         <translation>项目{}已存在于视频流中</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="228"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="240"/>
         <source>Please use another name.</source>
         <translation>请使用另一个名称。</translation>
     </message>
@@ -1344,22 +1344,22 @@ Please recheck the entered server address.</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="101"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="102"/>
         <source>New Line</source>
         <translation>新检测线段</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="101"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="102"/>
         <source>Name for new line:</source>
         <translation>新检测线段名称：</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="112"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="113"/>
         <source>New Region</source>
         <translation>新检测区域</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="112"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="113"/>
         <source>Name for new region:</source>
         <translation>新检测区域名称：</translation>
     </message>

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -1334,12 +1334,12 @@ Please recheck the entered server address.</source>
         <translation>已有任务</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.ui" line="217"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.ui" line="238"/>
         <source>Confirm</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.ui" line="224"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.ui" line="245"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -1372,6 +1372,11 @@ Please recheck the entered server address.</source>
         <location filename="../../dialogs/task_configuration/task_configuration.py" line="191"/>
         <source>Attempted to rename Zone {zone_id} to {zone_name} but the Zone no longer exists.</source>
         <translation>尝试将区域 {zone_id} 重命名为 {zone_name}，但该区域不再存在。</translation>
+    </message>
+    <message>
+        <location filename="../../dialogs/task_configuration/task_configuration.ui" line="167"/>
+        <source>Double click a zone to rename it</source>
+        <translation>双击区域以重命名</translation>
     </message>
 </context>
 <context>

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -1284,22 +1284,22 @@ Please recheck the entered server address.</source>
 <context>
     <name>TaskConfiguration</name>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="200"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="230"/>
         <source>Add points until done, then press &quot;Confirm&quot; button</source>
         <translation>添加点直到完成，然后按“确认”按钮</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="236"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="266"/>
         <source>Item Name Already Exists</source>
         <translation>名称已存在</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="237"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="267"/>
         <source>Item {} already exists in Stream</source>
         <translation>项目{}已存在于视频流中</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="240"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="270"/>
         <source>Please use another name.</source>
         <translation>请使用另一个名称。</translation>
     </message>
@@ -1362,6 +1362,11 @@ Please recheck the entered server address.</source>
         <location filename="../../dialogs/task_configuration/task_configuration.py" line="113"/>
         <source>Name for new region:</source>
         <translation>新检测区域名称：</translation>
+    </message>
+    <message>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="188"/>
+        <source>Unable to rename zone</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -1284,22 +1284,22 @@ Please recheck the entered server address.</source>
 <context>
     <name>TaskConfiguration</name>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="230"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="231"/>
         <source>Add points until done, then press &quot;Confirm&quot; button</source>
         <translation>添加点直到完成，然后按“确认”按钮</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="266"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="267"/>
         <source>Item Name Already Exists</source>
         <translation>名称已存在</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="267"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="268"/>
         <source>Item {} already exists in Stream</source>
         <translation>项目{}已存在于视频流中</translation>
     </message>
     <message>
-        <location filename="../../dialogs/task_configuration/task_configuration.py" line="270"/>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="271"/>
         <source>Please use another name.</source>
         <translation>请使用另一个名称。</translation>
     </message>
@@ -1365,7 +1365,12 @@ Please recheck the entered server address.</source>
     </message>
     <message>
         <location filename="../../dialogs/task_configuration/task_configuration.py" line="188"/>
-        <source>Unable to rename zone</source>
+        <source>Unable to rename Zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../dialogs/task_configuration/task_configuration.py" line="191"/>
+        <source>Attempted to rename Zone {zone_id} to {zone_name} but the Zone no longer exists.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1423,6 +1428,14 @@ Please recheck the entered server address.</source>
         <location filename="../../main_window/video_expanded_view/video_expanded_view.py" line="183"/>
         <source>This will delete all Zones, Detections, Alarms, Alerts, etc. associated with this stream and cannot be undone. This process will happen in the background and can take several minutes.&lt;br&gt;&lt;br&gt;Are you sure you want to continue?</source>
         <translation>这将删除所有此视频流相关的区域、检测结果、警报、报警信息等，并且无法撤消。这个流程会在后台发生&lt;br&gt;&lt;br&gt;可能需要几分钟。</translation>
+    </message>
+</context>
+<context>
+    <name>ZoneListAlarmItem</name>
+    <message>
+        <location filename="../../dialogs/task_configuration/widgets/zone_list_item.py" line="104"/>
+        <source>Editing of alarms is not currently not supported</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -1366,12 +1366,12 @@ Please recheck the entered server address.</source>
     <message>
         <location filename="../../dialogs/task_configuration/task_configuration.py" line="188"/>
         <source>Unable to rename Zone</source>
-        <translation type="unfinished"></translation>
+        <translation>无法重命名区域</translation>
     </message>
     <message>
         <location filename="../../dialogs/task_configuration/task_configuration.py" line="191"/>
         <source>Attempted to rename Zone {zone_id} to {zone_name} but the Zone no longer exists.</source>
-        <translation type="unfinished"></translation>
+        <translation>尝试将区域 {zone_id} 重命名为 {zone_name}，但该区域不再存在。</translation>
     </message>
 </context>
 <context>
@@ -1435,7 +1435,7 @@ Please recheck the entered server address.</source>
     <message>
         <location filename="../../dialogs/task_configuration/widgets/zone_list_item.py" line="104"/>
         <source>Editing of alarms is not currently not supported</source>
-        <translation type="unfinished"></translation>
+        <translation>目前不支持编辑预警</translation>
     </message>
 </context>
 <context>

--- a/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
+++ b/brainframe_qt/ui/resources/i18n/brainframe_zh.ts
@@ -1433,7 +1433,7 @@ Please recheck the entered server address.</source>
 <context>
     <name>ZoneListAlarmItem</name>
     <message>
-        <location filename="../../dialogs/task_configuration/widgets/zone_list_item.py" line="104"/>
+        <location filename="../../dialogs/task_configuration/widgets/zone_list_item.py" line="122"/>
         <source>Editing of alarms is not currently not supported</source>
         <translation>目前不支持编辑预警</translation>
     </message>

--- a/brainframe_qt/ui/resources/images/icons/edit_pencil.svg
+++ b/brainframe_qt/ui/resources/images/icons/edit_pencil.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:df71cec30d2dd80997cf80d90873e688e7942ccb53b2a785ff57436ae34a4713
-size 2917
+oid sha256:07034304fb15e15e31cc69ca8b6574d1dc3f0fd056b5bacae840eae56186fb19
+size 3819

--- a/brainframe_qt/ui/resources/images/icons/edit_pencil_inkscape.svg
+++ b/brainframe_qt/ui/resources/images/icons/edit_pencil_inkscape.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:993af1943c4bac5bb7e9d8486b31b957da8bbb0174ff0bd427a9d76ab51dcd0c
-size 4221
+oid sha256:7bb7f6c27ebdb4352963287197656d0d3b1067319608e0f071ba06cbe812f3e0
+size 4663

--- a/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/__init__.py
+++ b/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/__init__.py
@@ -1,2 +1,3 @@
 from .drag_and_drop_text_editor import DragAndDropTextEditor
+from .editable_label import EditableLabel
 from .placeholder_text_edit import PlaceholderTextEdit

--- a/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
+++ b/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
@@ -62,7 +62,11 @@ class EditableLabel(QStackedWidget):
         if not self._editing:
             return
 
+        # Block signals to prevent out-focus event from self._line_edit triggering
+        # self.finish_edit
+        self._line_edit.blockSignals(True)
         self.setCurrentWidget(self._label)
+        self._line_edit.blockSignals(False)
 
         self._editing = False
 

--- a/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
+++ b/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
@@ -1,8 +1,11 @@
-from PyQt5.QtCore import QObject, Qt
+from PyQt5.QtCore import QObject, Qt, pyqtSignal
+from PyQt5.QtGui import QMouseEvent, QKeyEvent
 from PyQt5.QtWidgets import QStackedWidget, QLabel, QLineEdit
 
 
 class EditableLabel(QStackedWidget):
+    text_changed = pyqtSignal(str)
+
     def __init__(self, text: str, *, parent: QObject):
         super().__init__(parent=parent)
 
@@ -12,8 +15,12 @@ class EditableLabel(QStackedWidget):
         self._text = ""
         self.text = text
 
+        self._editing = False
+
         self._init_layout()
         self._init_style()
+
+        self._init_signals()
 
     def _init_label(self) -> QLabel:
         label = QLabel(parent=self)
@@ -32,6 +39,17 @@ class EditableLabel(QStackedWidget):
     def _init_style(self) -> None:
         self.setAttribute(Qt.WA_StyledBackground, True)
 
+    def _init_signals(self) -> None:
+        self._line_edit.editingFinished.connect(self.finish_edit)
+
+    def keyPressEvent(self, event: QKeyEvent) -> None:
+        if self._editing and event.key() == Qt.Key_Escape:
+            self.cancel_edit()
+
+    def mouseDoubleClickEvent(self, event: QMouseEvent) -> None:
+        if not self._editing:
+            self.start_edit()
+
     @property
     def text(self) -> str:
         return self._label.text()
@@ -40,13 +58,35 @@ class EditableLabel(QStackedWidget):
     def text(self, text: str):
         self._label.setText(text)
 
-    def start_edit(self) -> None:
-        self._line_edit.setText(self.text)
-        self._line_edit.selectAll()
+    def cancel_edit(self) -> None:
+        if not self._editing:
+            return
 
-        self.setCurrentWidget(self._line_edit)
+        self.setCurrentWidget(self._label)
+
+        self._editing = False
 
     def finish_edit(self) -> None:
+        if not self._editing:
+            return
+
         self.text = self._line_edit.text()
 
         self.setCurrentWidget(self._label)
+
+        self._editing = False
+
+        self.text_changed.emit(self.text)
+
+    def start_edit(self) -> None:
+        if self._editing:
+            return
+
+        self._line_edit.setText(self.text)
+
+        self._line_edit.selectAll()
+        self._line_edit.setFocus()
+
+        self.setCurrentWidget(self._line_edit)
+
+        self._editing = True

--- a/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
+++ b/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
@@ -12,6 +12,9 @@ class EditableLabel(QStackedWidget):
         self._label = self._init_label()
         self._line_edit = self._init_line_edit()
 
+        self.editable = True
+        """If this is False, editing text is disabled"""
+
         self._text = ""
         self.text = text
 
@@ -47,6 +50,9 @@ class EditableLabel(QStackedWidget):
             self.cancel_edit()
 
     def mouseDoubleClickEvent(self, event: QMouseEvent) -> None:
+        if not self.editable:
+            return
+
         if not self._editing:
             self.start_edit()
 
@@ -67,6 +73,10 @@ class EditableLabel(QStackedWidget):
         self._editing = False
 
     def finish_edit(self) -> None:
+        if not self.editable:
+            self.cancel_edit()
+            return
+
         if not self._editing:
             return
 
@@ -79,7 +89,7 @@ class EditableLabel(QStackedWidget):
         self.text_changed.emit(self.text)
 
     def start_edit(self) -> None:
-        if self._editing:
+        if not self.editable or self._editing:
             return
 
         self._line_edit.setText(self.text)

--- a/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
+++ b/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
@@ -1,39 +1,25 @@
 from PyQt5.QtCore import QObject, Qt, pyqtSignal
-from PyQt5.QtGui import QMouseEvent, QKeyEvent
+from PyQt5.QtGui import QMouseEvent, QKeyEvent, QValidator
 from PyQt5.QtWidgets import QStackedWidget, QLabel, QLineEdit
 
 
 class EditableLabel(QStackedWidget):
     text_changed = pyqtSignal(str)
 
-    def __init__(self, text: str, *, parent: QObject):
+    def __init__(self, label: QLabel, line_edit: QLineEdit, *, parent: QObject):
         super().__init__(parent=parent)
 
-        self._label = self._init_label()
-        self._line_edit = self._init_line_edit()
+        self._label = label
+        self._line_edit = line_edit
 
         self.editable = True
         """If this is False, editing text is disabled"""
-
-        self._text = ""
-        self.text = text
-
         self._editing = False
 
         self._init_layout()
         self._init_style()
 
         self._init_signals()
-
-    def _init_label(self) -> QLabel:
-        label = QLabel(parent=self)
-
-        return label
-
-    def _init_line_edit(self) -> QLineEdit:
-        line_edit = QLineEdit(parent=self)
-
-        return line_edit
 
     def _init_layout(self) -> None:
         self.addWidget(self._label)
@@ -61,8 +47,16 @@ class EditableLabel(QStackedWidget):
         return self._label.text()
 
     @text.setter
-    def text(self, text: str):
+    def text(self, text: str) -> None:
         self._label.setText(text)
+
+    @property
+    def validator(self) -> QValidator:
+        return self._line_edit.validator()
+
+    @validator.setter
+    def validator(self, validator: QValidator) -> None:
+        self._line_edit.setValidator(validator)
 
     def cancel_edit(self) -> None:
         if not self._editing:

--- a/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
+++ b/brainframe_qt/ui/resources/ui_elements/widgets/text_edit/editable_label.py
@@ -1,0 +1,52 @@
+from PyQt5.QtCore import QObject, Qt
+from PyQt5.QtWidgets import QStackedWidget, QLabel, QLineEdit
+
+
+class EditableLabel(QStackedWidget):
+    def __init__(self, text: str, *, parent: QObject):
+        super().__init__(parent=parent)
+
+        self._label = self._init_label()
+        self._line_edit = self._init_line_edit()
+
+        self._text = ""
+        self.text = text
+
+        self._init_layout()
+        self._init_style()
+
+    def _init_label(self) -> QLabel:
+        label = QLabel(parent=self)
+
+        return label
+
+    def _init_line_edit(self) -> QLineEdit:
+        line_edit = QLineEdit(parent=self)
+
+        return line_edit
+
+    def _init_layout(self) -> None:
+        self.addWidget(self._label)
+        self.addWidget(self._line_edit)
+
+    def _init_style(self) -> None:
+        self.setAttribute(Qt.WA_StyledBackground, True)
+
+    @property
+    def text(self) -> str:
+        return self._label.text()
+
+    @text.setter
+    def text(self, text: str):
+        self._label.setText(text)
+
+    def start_edit(self) -> None:
+        self._line_edit.setText(self.text)
+        self._line_edit.selectAll()
+
+        self.setCurrentWidget(self._line_edit)
+
+    def finish_edit(self) -> None:
+        self.text = self._line_edit.text()
+
+        self.setCurrentWidget(self._label)


### PR DESCRIPTION
Resolves #194 

Review along with #196 which resolves #195 

TODO: 
- [x] Don't allow a user to rename a `Zone` to "Screen"

Feedback on whether this is intuitive enough would be appreciated